### PR TITLE
Arbeitsspeicher am Start auf 2048 erhöhen

### DIFF
--- a/docs/hyperv.md
+++ b/docs/hyperv.md
@@ -19,7 +19,7 @@ und mit der Installation von Ubuntu begonnen werden.
 * In Hyper-V-Manager eine neue VM erstellen
   * Name: jumpstart-vm
   * Typ: Generation 2
-  * Arbeitsspeicher beim Start: 1024
+  * Arbeitsspeicher beim Start: 2048
   * Netzwerk Verbindung: Default Switch
   * Festplatten Grösse: 64 GB
   * Betriebssystem von ISO installieren (hier das heruntergeladene Ubuntu ISO auswählen)


### PR DESCRIPTION
Für eine erfolgreiche Installation von Ubunutu muss der Arbeitsspeicher am Start auf 2048 erhöhte werden. Recommended System Requirements sind aktuell: 4 GB system memory.

Ansonsten tritt folgender fehler auf:


![grafik](https://github.com/scs/jumpstart-vm/assets/147705600/f87ff9b5-1217-45f0-bae6-ff987e217089)
